### PR TITLE
Allow to switch statistics feature off for compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,8 @@ The idle_callback is an optional callback that will be called when
 there is nothing to do (and we're not sleeping, see use_sleep),
 it's defined as void idle_callback(void). If you're not using it,
 specify NULL.
+
+Compile with define USI_TWI_WITHOUT_STATS set to exclude the statistics
+function from the generated object file. This saves about 300 bytes in the
+Flash memory. The define must be set via compiler options, otherwise it is
+not recognized in the usitwislave.c during compilation.

--- a/usitwislave.h
+++ b/usitwislave.h
@@ -11,6 +11,7 @@ void		usi_twi_slave(uint8_t slave_address, uint8_t use_sleep,
 				volatile uint8_t *output_buffer_length, volatile uint8_t *output_buffer),
 				void (*idle_callback)(void));
 
+#ifndef USI_TWI_WITHOUT_STATS
 void		usi_twi_enable_stats(uint8_t onoff);
 uint16_t	usi_twi_stats_start_conditions(void);
 uint16_t	usi_twi_stats_stop_conditions(void);
@@ -18,5 +19,6 @@ uint16_t	usi_twi_stats_error_conditions(void);
 uint16_t	usi_twi_stats_overflow_conditions(void);
 uint16_t	usi_twi_stats_local_frames(void);
 uint16_t	usi_twi_stats_idle_calls(void);
+#endif //USI_TWI_WITHOUT_STATS
 
 #endif


### PR DESCRIPTION
Compiling the statistics feature results in about 300 bytes extra code in the Flash memory. Since I do not use this feature, I added #ifndef blocks to switch it off completely, thus saving me space on the device. 
